### PR TITLE
Add an option to align the timer to the left

### DIFF
--- a/UI/Components/Timer.cs
+++ b/UI/Components/Timer.cs
@@ -176,8 +176,19 @@ namespace LiveSplit.UI.Components
             var smallAscent = smallSizeMultiplier * smallFont.FontFamily.GetCellAscent(smallFont.Style);
             var shift = (height - ascent - descent) / 2f;
 
-            BigTextLabel.X = width - 499 - SmallTextLabel.ActualWidth;
-            SmallTextLabel.X = width - SmallTextLabel.ActualWidth - 6;
+            if (Settings.AlignLeft)
+            {
+                BigTextLabel.X = 0;
+                SmallTextLabel.X = 0 + BigTextLabel.ActualWidth;
+                BigTextLabel.HorizontalAlignment = StringAlignment.Near;
+            }
+            else
+            {
+                BigTextLabel.X = width - 499 - SmallTextLabel.ActualWidth;
+                SmallTextLabel.X = width - SmallTextLabel.ActualWidth - 6;
+                BigTextLabel.HorizontalAlignment = StringAlignment.Far;
+            }
+            
             BigTextLabel.Y = shift;
             SmallTextLabel.Y = shift + ascent - smallAscent;
             BigTextLabel.Height = 150f;

--- a/UI/Components/TimerSettings.Designer.cs
+++ b/UI/Components/TimerSettings.Designer.cs
@@ -43,6 +43,7 @@
             this.btnColor2 = new System.Windows.Forms.Button();
             this.label11 = new System.Windows.Forms.Label();
             this.chkCenterTimer = new System.Windows.Forms.CheckBox();
+            this.chkAlignTimerLeft = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.cmbDigitsFormat = new System.Windows.Forms.ComboBox();
@@ -74,6 +75,7 @@
             this.tableLayoutPanel1.Controls.Add(this.btnColor2, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.chkCenterTimer, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.chkAlignTimerLeft, 1, 5);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.label3, 0, 6);
             this.tableLayoutPanel1.Controls.Add(this.cmbDigitsFormat, 1, 6);
@@ -273,6 +275,18 @@
             this.chkCenterTimer.TabIndex = 7;
             this.chkCenterTimer.Text = "Align to Center";
             this.chkCenterTimer.UseVisualStyleBackColor = true;
+            //
+            // chkAlignTimerLeft
+            //
+            this.tableLayoutPanel1.SetColumnSpan(this.chkAlignTimerLeft, 4);
+            this.chkAlignTimerLeft.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkAlignTimerLeft.AutoSize = true;
+            this.chkAlignTimerLeft.Location = new System.Drawing.Point(7, 205);
+            this.chkAlignTimerLeft.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkAlignTimerLeft.Name = "chkAlignTimerLeft";
+            this.chkAlignTimerLeft.Size = new System.Drawing.Size(147, 17);
+            this.chkAlignTimerLeft.Text = "Align to the left";
+            this.chkAlignTimerLeft.UseVisualStyleBackColor = true;
             // 
             // label2
             // 
@@ -390,6 +404,7 @@
         private System.Windows.Forms.Button btnColor2;
         private System.Windows.Forms.Label label11;
         private System.Windows.Forms.CheckBox chkCenterTimer;
+        private System.Windows.Forms.CheckBox chkAlignTimerLeft;
         private System.Windows.Forms.ComboBox cmbTimingMethod;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.ComboBox cmbDigitsFormat;

--- a/UI/Components/TimerSettings.cs
+++ b/UI/Components/TimerSettings.cs
@@ -43,6 +43,8 @@ namespace LiveSplit.UI.Components
         public bool OverrideSplitColors { get; set; }
 
         public bool CenterTimer { get; set; }
+        
+        public bool AlignLeft { get; set; }
 
         public bool ShowGradient { get; set; }
 
@@ -82,6 +84,7 @@ namespace LiveSplit.UI.Components
             btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
             btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
             chkCenterTimer.DataBindings.Add("Checked", this, "CenterTimer", false, DataSourceUpdateMode.OnPropertyChanged);
+            chkAlignTimerLeft.DataBindings.Add("Checked", this, "AlignLeft", false, DataSourceUpdateMode.OnPropertyChanged);
             cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
             trkDecimalsSize.DataBindings.Add("Value", this, "DecimalsSize", false, DataSourceUpdateMode.OnPropertyChanged);
             cmbDigitsFormat.DataBindings.Add("SelectedItem", this, "DigitsFormat", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -174,6 +177,7 @@ namespace LiveSplit.UI.Components
             BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.Transparent);
             GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], DeltasGradientType.Plain.ToString());
             CenterTimer = SettingsHelper.ParseBool(element["CenterTimer"], false);
+            AlignLeft = SettingsHelper.ParseBool(element["AlignLeft"], false);
             TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Current Timing Method");
 
             if (version >= new Version(1, 3))
@@ -231,6 +235,7 @@ namespace LiveSplit.UI.Components
             SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
             SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
             SettingsHelper.CreateSetting(document, parent, "CenterTimer", CenterTimer) ^
+            SettingsHelper.CreateSetting(document, parent, "AlignLeft", AlignLeft) ^
             SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod) ^
             SettingsHelper.CreateSetting(document, parent, "DecimalsSize", DecimalsSize);
         }


### PR DESCRIPTION
This patch adds an option so that the timer is aligned to the left instead of to the right, this probably could become a drop down to select between the three different alignments but it would probably require a bit more refactoring

Putting this as a draft pull request for now because:
- [ ] There is a bug where the timer doesn't update properly if the timer loses a digit (when reseting for example, if the timer goes from XX.XX to X.XX then the bug would happen)
- [ ] The setting for it would probably need to be improved and merge it with the "Center Timer" option