### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.Timer/UI/Components/Timer.cs
+++ b/src/LiveSplit.Timer/UI/Components/Timer.cs
@@ -10,6 +10,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimerFont)]
 public class Timer : IComponent
 {
     public SimpleLabel BigTextLabel { get; set; }


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688